### PR TITLE
Use existing environment variables in .env values

### DIFF
--- a/dotenv.py
+++ b/dotenv.py
@@ -25,4 +25,5 @@ def parse_dotenv(dotenv):
             continue
         k, v = line.split('=', 1)
         v = v.strip("'").strip('"')
+        v = os.path.expandvars(v)
         yield k, v


### PR DESCRIPTION
I needed to use some existing environment variables when creating the .env for certain systems.  As is, dotenv does nothing but strip the outside quotes from the values.  All this commit adds is calling os.path.expandvars() to replace variables with their values.
