### PR TITLE
Refactor the parser to handle more use-cases

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DOTENV=true

--- a/dotenv.py
+++ b/dotenv.py
@@ -1,6 +1,35 @@
 import os
+import re
 import sys
 import warnings
+
+
+line_re = re.compile(r"""
+    ^
+    (?:export\s+)?      # optional export
+    ([\w\.]+)           # key
+    (?:\s*=\s*|:\s+?)   # separator
+    (                   # optional value begin
+        '(?:\'|[^'])*'  #   single quoted value
+        |               #   or
+        "(?:\"|[^"])*"  #   double quoted value
+        |               #   or
+        [^#\n]+         #   unquoted value
+    )?                  # value end
+    (?:\s*\#.*)?        # optional comment
+    $
+""", re.VERBOSE)
+
+variable_re = re.compile(r"""
+    (\\)?               # is it escaped with a backslash?
+    (\$)                # literal $
+    (                   # collect braces with var for sub
+        \{?             #   allow brace wrapping
+        ([A-Z0-9_]+)    #   match the variable
+        \}?             #   closing brace
+    )                   # braces end
+""", re.IGNORECASE | re.VERBOSE)
+
 
 def read_dotenv(dotenv=None):
     """
@@ -12,17 +41,50 @@ def read_dotenv(dotenv=None):
     if dotenv is None:
         frame = sys._getframe()
         dotenv = os.path.join(os.path.dirname(frame.f_back.f_code.co_filename), '.env')
-        if not os.path.exists(dotenv):
-            warnings.warn("not reading %s - it doesn't exist." % dotenv)
-            return
-    for k, v in parse_dotenv(dotenv):
-        os.environ.setdefault(k, v)
+    if os.path.exists(dotenv):
+        file = open(dotenv)
+        for k, v in parse_dotenv(file.read()).items():
+            os.environ.setdefault(k, v)
+        file.close()
+    else:
+        warnings.warn("not reading %s - it doesn't exist." % dotenv)
 
-def parse_dotenv(dotenv):
-    for line in open(dotenv):
-        line = line.strip()
-        if not line or line.startswith('#') or '=' not in line:
-            continue
-        k, v = line.split('=', 1)
-        v = v.strip("'").strip('"')
-        yield k, v
+
+def parse_dotenv(content):
+    env = {}
+    for line in content.splitlines():
+        m1 = line_re.search(line)
+        if m1:
+            key, value = m1.groups()
+            if value is None:
+                value = ''
+
+            # remove leading/trailing whitespace
+            value = value.strip()
+
+            # remove surrounding quotes
+            m2 = re.match(r'^([\'"])(.*)\1$', value)
+            if m2:
+                quotemark, value = m2.groups()
+            else:
+                quotemark = None
+
+            # unescape all characters except $ so variables can be escaped properly
+            if quotemark == '"':
+                value = re.sub(r'\\([^$])', '\1', value)
+
+            if quotemark != "'":
+                # substitute variables in a value
+                for parts in variable_re.findall(value):
+                    if parts[0] == '\\':
+                        # variable is escaped, don't replace it
+                        replace = ''.join(parts[1:-1])
+                    else:
+                        # replace it with the value from the environment
+                        replace = env.get(parts[-1], os.environ.get(parts[-1], ''))
+                    value = value.replace(''.join(parts[0:-1]), replace)
+
+            env[key] = value
+        elif not re.search(r'^\s*(?:#.*)?$', line):  # not comment or blank line
+            warnings.warn("Line %s doesn't match format" % repr(line), SyntaxWarning)
+    return env

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author_email = "jacob@jacobian.org",
     url = "http://github.com/jacobian/django-dotenv",
     py_modules = ['dotenv'],
+    test_suite = 'tests',
     classifiers = [
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,100 @@
+import os
+import unittest
+import warnings
+
+from dotenv import parse_dotenv, read_dotenv
+
+
+class ParseDotenvTestCase(unittest.TestCase):
+    def test_parses_unquoted_values(self):
+        self.assertEqual(parse_dotenv('FOO=bar'), {'FOO': 'bar'})
+
+    def test_parses_values_with_spaces_around_equal_sign(self):
+        self.assertEqual(parse_dotenv('FOO =bar'), {'FOO': 'bar'})
+        self.assertEqual(parse_dotenv('FOO= bar'), {'FOO': 'bar'})
+
+    def test_parses_double_quoted_values(self):
+        self.assertEqual(parse_dotenv('FOO="bar"'), {'FOO': 'bar'})
+
+    def test_parses_single_quoted_values(self):
+        self.assertEqual(parse_dotenv("FOO='bar'"), {'FOO': 'bar'})
+
+    def test_parses_escaped_double_quotes(self):
+        self.assertEqual(parse_dotenv('FOO="escaped\"bar"'), {'FOO': 'escaped"bar'})
+
+    def test_parses_empty_values(self):
+        self.assertEqual(parse_dotenv('FOO='), {'FOO': ''})
+
+    def test_expands_variables_found_in_values(self):
+        self.assertEqual(parse_dotenv("FOO=test\nBAR=$FOO"), {'FOO': 'test', 'BAR': 'test'})
+
+    def test_expands_variables_wrapped_in_brackets(self):
+        self.assertEqual(parse_dotenv("FOO=test\nBAR=${FOO}bar"), {'FOO': 'test', 'BAR': 'testbar'})
+
+    def test_expands_variables_from_environ_if_not_found_in_local_env(self):
+        os.environ.setdefault('FOO', 'test')
+        self.assertEqual(parse_dotenv('BAR=$FOO'), {'BAR': 'test'})
+
+    def test_expands_undefined_variables_to_an_empty_string(self):
+        self.assertEqual(parse_dotenv('BAR=$FOO'), {'BAR': ''})
+
+    def test_expands_variables_in_double_quoted_values(self):
+        self.assertEqual(parse_dotenv("FOO=test\nBAR=\"quote $FOO\""), {'FOO': 'test', 'BAR': 'quote test'})
+
+    def test_does_not_expand_variables_in_single_quoted_values(self):
+        self.assertEqual(parse_dotenv("BAR='quote $FOO'"), {'BAR': 'quote $FOO'})
+
+    def test_does_not_expand_escaped_variables(self):
+        self.assertEqual(parse_dotenv('FOO="foo\\$BAR"'), {'FOO': 'foo$BAR'})
+        self.assertEqual(parse_dotenv('FOO="foo\${BAR}"'), {'FOO': 'foo${BAR}'})
+
+    def test_parses_export_keyword(self):
+        self.assertEqual(parse_dotenv('export FOO=bar'), {'FOO': 'bar'})
+
+    def test_parses_key_with_dot_in_the_name(self):
+        self.assertEqual(parse_dotenv('FOO.BAR=foobar'), {'FOO.BAR': 'foobar'})
+
+    def test_strips_unquoted_values(self):
+        self.assertEqual(parse_dotenv('foo=bar '), {'foo': 'bar'})  # not 'bar '
+
+    def test_warns_if_line_format_is_incorrect(self):
+        with warnings.catch_warnings(record=True) as w:
+            parse_dotenv('lol$wut')
+
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, SyntaxWarning)
+            self.assertEqual(str(w[0].message), "Line 'lol$wut' doesn't match format")
+
+    def test_ignores_empty_lines(self):
+        self.assertEqual(parse_dotenv("\n \t  \nfoo=bar\n \nfizz=buzz"), {'foo': 'bar', 'fizz': 'buzz'})
+
+    def test_ignores_inline_comments(self):
+        self.assertEqual(parse_dotenv('foo=bar # this is foo'), {'foo': 'bar'})
+
+    def test_allows_hash_in_quoted_values(self):
+        self.assertEqual(parse_dotenv('foo="bar#baz" # comment '), {'foo': 'bar#baz'})
+
+    def test_ignores_comment_lines(self):
+        self.assertEqual(parse_dotenv("\n\n\n # HERE GOES FOO \nfoo=bar"), {'foo': 'bar'})
+
+    def test_parses_hash_in_quoted_values(self):
+        self.assertEqual(parse_dotenv('foo="ba#r"'), {'foo': 'ba#r'})
+        self.assertEqual(parse_dotenv("foo='ba#r'"), {'foo': 'ba#r'})
+
+
+class ReadDotenvTestCase(unittest.TestCase):
+    def test_defaults_to_dotenv(self):
+        read_dotenv()
+        self.assertEqual(os.environ.get('DOTENV'), 'true')
+
+    def test_reads_the_file(self):
+        read_dotenv('.env')
+        self.assertEqual(os.environ.get('DOTENV'), 'true')
+
+    def test_warns_if_file_does_not_exist(self):
+        with warnings.catch_warnings(record=True) as w:
+            read_dotenv('.does_not_exist')
+
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, UserWarning)
+            self.assertEqual(str(w[0].message), "not reading .does_not_exist - it doesn't exist.")


### PR DESCRIPTION
Carrying on the conversation started in #3, I've refactored the parser to handle more use-cases and better match default behaviour (based off of [bkeepers/dotenv](https://github.com/bkeepers/dotenv)).

A summary of the changes:
- Use a regex for line matching
- Substitute environment variables in a value
- Correct behaviour between no quote/single quote/double quote values
- Handle correct escaping of values
- Add in lots of tests
