### PR TITLE
Add dotenv directory parsing and related tests

### DIFF
--- a/dotenv.py
+++ b/dotenv.py
@@ -45,6 +45,9 @@ def read_dotenv(dotenv=None):
         frame_filename = sys._getframe().f_back.f_code.co_filename
         dotenv = os.path.join(os.path.dirname(frame_filename), '.env')
 
+    if os.path.isdir(dotenv) and os.path.isfile(os.path.join(dotenv, '.env')):
+        dotenv = os.path.join(dotenv, '.env')
+
     if os.path.exists(dotenv):
         with open(dotenv) as f:
             for k, v in parse_dotenv(f.read()).items():

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import unittest
 import warnings
 
@@ -130,3 +131,24 @@ class ReadDotenvTestCase(unittest.TestCase):
                 str(w[0].message),
                 "Not reading .does_not_exist - it doesn't exist."
             )
+
+
+class ParseDotenvDirectoryTestCase(unittest.TestCase):
+    """Test parsing a dotenv file given the directory where it lives"""
+
+    def setUp(self):
+        # Define our dotenv directory
+        self.dotenv_dir = os.path.join(
+            os.path.dirname(__file__), 'dotenv_dir')
+        # Create the directory
+        os.mkdir(self.dotenv_dir)
+        # Copy the test .env file to our new directory
+        shutil.copy2(os.path.abspath('.env'), self.dotenv_dir)
+
+    def tearDown(self):
+        if os.path.exists(self.dotenv_dir):
+            shutil.rmtree(self.dotenv_dir)
+
+    def test_can_read_dotenv_given_its_directory(self):
+        read_dotenv(self.dotenv_dir)
+        self.assertEqual(os.environ.get('DOTENV'), 'true')


### PR DESCRIPTION
Resolves #10
Adds support for reading a `.env` file given a directory where it lives