### PR TITLE
Handle double quotes in values correctly

### DIFF
--- a/dotenv.py
+++ b/dotenv.py
@@ -78,7 +78,7 @@ def parse_dotenv(content):
 
             # Unescape all chars except $ so variables can be escaped properly
             if quotemark == '"':
-                value = re.sub(r'\\([^$])', '\1', value)
+                value = re.sub(r'\\([^$])', r'\1', value)
 
             if quotemark != "'":
                 # Substitute variables in a value

--- a/tests.py
+++ b/tests.py
@@ -26,7 +26,7 @@ class ParseDotenvTestCase(unittest.TestCase):
         self.assertEqual(env, {'FOO': 'bar'})
 
     def test_parses_escaped_double_quotes(self):
-        env = parse_dotenv('FOO="escaped\"bar"')
+        env = parse_dotenv('FOO="escaped\\"bar"')
         self.assertEqual(env, {'FOO': 'escaped"bar'})
 
     def test_parses_empty_values(self):


### PR DESCRIPTION
The `re.sub` doesn't work because the `\1` needs to be a raw string for Python to not interpret it as an escaped character.

Fixes jpadilla/django-dotenv#17