### PR TITLE
#26: Adding an "overwrite" flag to read_dotenv, False by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ sudo: false
 env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27
-    - TOX_ENV=py33
     - TOX_ENV=py34
     - TOX_ENV=py35
 

--- a/dotenv.py
+++ b/dotenv.py
@@ -34,17 +34,17 @@ variable_re = re.compile(r"""
 """, re.IGNORECASE | re.VERBOSE)
 
 
-def read_dotenv(dotenv=None, overwrite=False):
+def read_dotenv(dotenv=None, override=False):
     """
     Read a .env file into os.environ.
 
     If not given a path to a dotenv path, does filthy magic stack backtracking
     to find manage.py and then find the dotenv.
 
-    If tests rely on .env files, setting the overwrite flag to True is a safe way to ensure tests run consistently
-    across all environments.
+    If tests rely on .env files, setting the overwrite flag to True is a safe
+    way to ensure tests run consistently across all environments.
 
-    :param overwrite: True if values in .env should overwrite export environment variables.
+    :param override: True if values in .env should override system variables.
     """
     if dotenv is None:
         frame_filename = sys._getframe().f_back.f_code.co_filename
@@ -56,7 +56,7 @@ def read_dotenv(dotenv=None, overwrite=False):
     if os.path.exists(dotenv):
         with open(dotenv) as f:
             for k, v in parse_dotenv(f.read()).items():
-                if overwrite:
+                if override:
                     os.environ[k] = v
                 else:
                     os.environ.setdefault(k, v)

--- a/dotenv.py
+++ b/dotenv.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'
 
 
 line_re = re.compile(r"""

--- a/dotenv.py
+++ b/dotenv.py
@@ -34,12 +34,17 @@ variable_re = re.compile(r"""
 """, re.IGNORECASE | re.VERBOSE)
 
 
-def read_dotenv(dotenv=None):
+def read_dotenv(dotenv=None, overwrite=False):
     """
     Read a .env file into os.environ.
 
     If not given a path to a dotenv path, does filthy magic stack backtracking
     to find manage.py and then find the dotenv.
+
+    If tests rely on .env files, setting the overwrite flag to True is a safe way to ensure tests run consistently
+    across all environments.
+
+    :param overwrite: True if values in .env should overwrite export environment variables.
     """
     if dotenv is None:
         frame_filename = sys._getframe().f_back.f_code.co_filename
@@ -51,7 +56,10 @@ def read_dotenv(dotenv=None):
     if os.path.exists(dotenv):
         with open(dotenv) as f:
             for k, v in parse_dotenv(f.read()).items():
-                os.environ.setdefault(k, v)
+                if overwrite:
+                    os.environ[k] = v
+                else:
+                    os.environ.setdefault(k, v)
     else:
         warnings.warn("Not reading {0} - it doesn't exist.".format(dotenv),
                       stacklevel=2)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Topic :: Internet :: WWW/HTTP',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-flake8,
-    py27, py32, py33, py34, py35
+    py27, py32, py34, py35
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
PR for issue #26.

Allows for an optional "overwrite" parameter, False by default (so nothing existing breaks). Documented as well.

This would especially be useful when running tests, so test cases can still rely on a .env file and ensure it will override pre-existing environment variables that may not be suitable to use when running tests.