### PR TITLE
Add safe option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DOTENV=true
+DOTENV_EXAMPLE=true


### PR DESCRIPTION
- Pull Requst for this issue https://github.com/jpadilla/django-dotenv/issues/40.
- Add a new parameter `safe` to read_dotenv.
- If `.env.example` file exists, make sure that each values from `.env.example` contains a value in `.env`.