### PR TITLE
Drop Python versions 2.7 and 3.4; add version 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-# This is required to get Travis to run Python 3.7
-# https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
-sudo: required
-dist: xenial
-
 language: python
 
 install:
@@ -10,17 +5,15 @@ install:
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-    - python: 3.7
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.8
       env: TOXENV=flake8
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django-dotenv
 Original implementation was written by
 `@jacobian <https://github.com/jacobian>`__.
 
-Tested on Python 2.7, 3.4, 3.5, 3.6, and 3.7.
+Tested on Python 3.5, 3.6, 3.7 and 3.8.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import os
 import re
 import sys
@@ -44,12 +43,11 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist =
     flake8,
-    py27,
-    py34,
     py35,
     py36,
     py37,
+    py38,
 
 [testenv]
 commands = python setup.py test
 
 [testenv:flake8]
-deps = flake8==2.4.0
+deps = flake8
 commands = flake8 dotenv.py --verbose


### PR DESCRIPTION
This PR updates the versions of Python supported by this library.

It drops versions 2.7 and 3.4 from the matrix, and adds version 3.8 .