### PR TITLE
Test on Python 3.9 and 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,10 @@
 [tox]
 envlist =
-    flake8,
-    py35,
-    py36,
-    py37,
-    py38,
+    flake8
+    py{35,36,37,38,39,310}
 
 [testenv]
-commands = python setup.py test
+commands = python -m unittest -v
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
* Add classifier tags
* Add tox test environments
* Simplify tox envlist syntax
* Move from `python setup.py test` to directly invoking unittest, to avoid this warning from setuptools:

```
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
```